### PR TITLE
update to 1.3.0

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -3,9 +3,9 @@
   "title": "eggd_cgppindel",
   "summary": "cgppindel app for DNAnexus",
   "dxapi": "1.0.0",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "properties": {
-    "githubRelease": "v1.2.0"
+    "githubRelease": "v1.3.0"
   },
   "inputSpec": [
     {
@@ -197,21 +197,21 @@
   "runSpec": {
     "timeoutPolicy": {
       "*": {
-        "hours": 3
+        "hours": 24
       }
     },
     "interpreter": "bash",
     "file": "src/cgppindel.sh",
     "distribution": "Ubuntu",
-    "release": "20.04",
+    "release": "24.04",
     "version": "0",
     "headJobOnDemand": true,
     "assetDepends": [
       {
-        "name": "htslib",
+        "name": "htslib_suite_asset",
         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-        "folder": "/app_assets/htslib/htslib_v1.15.0",
-        "version": "1.15.0"
+        "folder": "/app_assets/htslib/htslib_v1.22.0",
+        "version": "1.22"
       }
     ]
   },
@@ -232,7 +232,7 @@
     "aws:eu-central-1": {
       "systemRequirements": {
         "*": {
-          "instanceType": "mem1_ssd2_v2_x4"
+          "instanceType": "mem1_ssd2_v2_x8"
         }
       }
     }

--- a/dxapp.json
+++ b/dxapp.json
@@ -145,6 +145,14 @@
         "*bai"
       ],
       "help": "Normal BAM index"
+    },
+    {
+      "name": "exclude",
+      "label": "Exclude contigs",
+      "class": "string",
+      "default": "",
+      "optional": true,
+      "help": "Comma separated list of contigs to exclude from analysis"
     }
   ],
   "outputSpec": [

--- a/src/cgppindel.sh
+++ b/src/cgppindel.sh
@@ -36,13 +36,6 @@ main() {
     #Add all inputs in the same folder to enable indeces to be found.
     find ~/in -type f -name "*" -print0 | xargs -0 -I {} mv {} ~/input
 
-    # Make option where exclude provided
-    #if [ -z "$exclude" ]; then
-    #    exclude=""
-    #else
-    #    exclude="-exclude '$exclude'"
-    #fi
-
     # Unzip fasta reference
     gzip -d ~/input/$reference_name
 
@@ -63,13 +56,13 @@ main() {
     -simrep /data/input/$simrep_name \
     -genes /data/input/$genes_name \
     -unmatched /data/input/$unmatched_name \
-    -assembly $assembly \
+    -assembly "$assembly" \
     -species Human \
-    -seqtype $seqtype \
+    -seqtype "$seqtype" \
     -filter /data/input/$filter_name \
     -tumour /data/input/$tumour_name \
     -normal /data/input/$normal_name \
-    -exclude $exclude \
+    -exclude "$exclude" \
     -outdir /data/out/cgppindel_output
 
     # Add Allele frequency (AF) and Read depth (DP) onto cgppindel output file

--- a/src/cgppindel.sh
+++ b/src/cgppindel.sh
@@ -17,6 +17,7 @@ main() {
     echo "Value of filter: '$filter'"
     echo "Value of tumour: '$tumour'"
     echo "Value of normal: '$normal'"
+    echo "Value of exclude: '$exclude'"
     
     # Create input/output directories
     mkdir input
@@ -34,6 +35,13 @@ main() {
 
     #Add all inputs in the same folder to enable indeces to be found.
     find ~/in -type f -name "*" -print0 | xargs -0 -I {} mv {} ~/input
+
+    # Make option where exclude provided
+    #if [ -z "$exclude" ]; then
+    #    exclude=""
+    #else
+    #    exclude="-exclude '$exclude'"
+    #fi
 
     # Unzip fasta reference
     gzip -d ~/input/$reference_name
@@ -61,6 +69,7 @@ main() {
     -filter /data/input/$filter_name \
     -tumour /data/input/$tumour_name \
     -normal /data/input/$normal_name \
+    -exclude $exclude \
     -outdir /data/out/cgppindel_output
 
     # Add Allele frequency (AF) and Read depth (DP) onto cgppindel output file


### PR DESCRIPTION
24h timeout
Ubuntu 24

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_cgppindel/14)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Exclude contigs" input allowing comma-separated contigs to be omitted from analysis.
  * CLI/runtime now accepts and displays the exclude option when provided.

* **Chores**
  * Bumped application version to 1.3.0 and release tag to v1.3.0.
  * Upgraded base OS to 24.04 and core toolkit asset to a newer release.
  * Increased execution timeout to 24 hours and raised allocated instance type for more memory.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->